### PR TITLE
Revert "[release-2.4] maintain the cluster name label by import controller"

### DIFF
--- a/controllers/clusterclaims/clusterclaims-controller.go
+++ b/controllers/clusterclaims/clusterclaims-controller.go
@@ -148,7 +148,10 @@ func createManagedCluster(
 			}
 		}
 
-		//TODO maintain label for claim
+		// Use the ClusterClaim name instead of the actual cluster name if a name was not included from the ClusterClaim
+		if _, ok := newLabels["name"]; !ok {
+			newLabels["name"] = claimName
+		}
 		newLabels["vendor"] = "OpenShift"  // This is always true
 		newLabels["cloud"] = "auto-detect" //This is used to detect cloud provider, like: GCP,AWS
 

--- a/controllers/clusterclaims/clusterclaims-controller_test.go
+++ b/controllers/clusterclaims/clusterclaims-controller_test.go
@@ -154,6 +154,7 @@ func TestReconcileClusterClaimsLabelCopy(t *testing.T) {
 	err = ccr.Client.Get(ctx, getNamespaceName("", CLUSTER01), &mc)
 	assert.Nil(t, err, "nil, when managedCluster resource is retrieved")
 
+	assert.Equal(t, mc.Labels["name"], CC_NAME, "label name should equal clusterClaim name")
 	assert.Equal(t, mc.Labels["vendor"], "OpenShift", "label vendor should equal OpenShift")
 	assert.Equal(t, mc.Labels["usage"], "production", "label usage should equal production")
 
@@ -328,6 +329,7 @@ func TestReconcileClusterClaimsLabelCopyForRegionAws(t *testing.T) {
 	err = ccr.Client.Get(ctx, getNamespaceName("", CLUSTER01), &mc)
 	assert.Nil(t, err, "nil, when managedCluster resource is retrieved")
 
+	assert.Equal(t, mc.Labels["name"], CC_NAME, "label name should equal clusterClaim name")
 	assert.Equal(t, mc.Labels["region"], "us-east-1", "label region should equal us-east-1")
 }
 
@@ -348,6 +350,7 @@ func TestReconcileClusterClaimsLabelCopyForRegionGcp(t *testing.T) {
 	err = ccr.Client.Get(ctx, getNamespaceName("", CLUSTER01), &mc)
 	assert.Nil(t, err, "nil, when managedCluster resource is retrieved")
 
+	assert.Equal(t, mc.Labels["name"], CC_NAME, "label name should equal clusterClaim name")
 	assert.Equal(t, mc.Labels["region"], "europe-west3", "label region should equal europe-west3")
 }
 
@@ -368,6 +371,7 @@ func TestReconcileClusterClaimsLabelCopyForRegionAzure(t *testing.T) {
 	err = ccr.Client.Get(ctx, getNamespaceName("", CLUSTER01), &mc)
 	assert.Nil(t, err, "nil, when managedCluster resource is retrieved")
 
+	assert.Equal(t, mc.Labels["name"], CC_NAME, "label name should equal clusterClaim name")
 	assert.Equal(t, mc.Labels["region"], "centralus", "label region should equal centralus")
 }
 
@@ -392,6 +396,7 @@ func TestReconcileClusterClaimsWithNoLabel(t *testing.T) {
 	err = ccr.Client.Get(ctx, getNamespaceName("", CLUSTER01), &mc)
 	assert.Nil(t, err, "nil, when managedCluster resource is retrieved")
 
+	assert.Equal(t, mc.Labels["name"], CC_NAME, "label name should equal clusterClaim name")
 	assert.Equal(t, mc.Labels["region"], "centralus", "label region should equal centralus")
 }
 


### PR DESCRIPTION
Reverts stolostron/clusterclaims-controller#28

Signed-off-by: Wei Liu [liuweixa@redhat.com](mailto:liuweixa@redhat.com)