### PR TITLE
Fix RHEL version skew

### DIFF
--- a/Dockerfile.prow
+++ b/Dockerfile.prow
@@ -5,7 +5,7 @@ COPY . .
 
 RUN make -f Makefile.prow compile
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 ENV USER_UID=1001
 

--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -1,11 +1,11 @@
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_1.22 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.22 AS builder
 
 WORKDIR /go/src/github.com/stolostron/clusterclaims-controller
 COPY . .
 
 RUN make -f Makefile.prow compile
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 ENV USER_UID=1001
 


### PR DESCRIPTION
The Go 1.22 builder image is built with UBI9, so passing the binary to a UBI8 image with CGO enabled is broken.

Signed-off-by: Dale Haiducek <19750917+dhaiducek@users.noreply.github.com>