### PR TITLE
ACM-16314: train-22 upgrade hive api to latest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.22.0
 
 require (
 	github.com/go-logr/logr v1.4.2
-	github.com/openshift/hive/apis v0.0.0-20241111235012-3ccd44ddc83f
+	github.com/openshift/hive/apis v0.0.0-20241211214914-af54e2fbd990
 	github.com/stretchr/testify v1.9.0
 	go.uber.org/zap v1.26.0
 	k8s.io/api v0.31.1

--- a/go.sum
+++ b/go.sum
@@ -174,6 +174,8 @@ github.com/openshift/custom-resource-status v1.1.3-0.20220503160415-f2fdb4999d87
 github.com/openshift/custom-resource-status v1.1.3-0.20220503160415-f2fdb4999d87/go.mod h1:DB/Mf2oTeiAmVVX1gN+NEqweonAPY0TKUwADizj8+ZA=
 github.com/openshift/hive/apis v0.0.0-20241111235012-3ccd44ddc83f h1:/Bz8bhGGynSbZ6ybQI2kD0wKJtFyOmbcQ1+oz0jY2n8=
 github.com/openshift/hive/apis v0.0.0-20241111235012-3ccd44ddc83f/go.mod h1:sC+SHtUc3K2VPamSYSnSoHlLog/XM8TKc9vcN6roXHk=
+github.com/openshift/hive/apis v0.0.0-20241211214914-af54e2fbd990 h1:jv9l6Szmles77hWSlDO4PiwejHF/Z21PS2otxcL2rKM=
+github.com/openshift/hive/apis v0.0.0-20241211214914-af54e2fbd990/go.mod h1:sC+SHtUc3K2VPamSYSnSoHlLog/XM8TKc9vcN6roXHk=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-16314