### PR TITLE
ACM-16131: add back the clusterclaim kind and api version for the provisioner annotation

### DIFF
--- a/controllers/managedcluster/managedcluster-controller.go
+++ b/controllers/managedcluster/managedcluster-controller.go
@@ -79,8 +79,8 @@ func (r *ManagedClusterReconciler) Reconcile(ctx context.Context, request ctrl.R
 		return ctrl.Result{}, err
 	}
 
-	// annotation format is <name>.<namespace>
-	expectedProvisioner := fmt.Sprintf("%s.%s", claimName, claimNamespace)
+	// annotation format is <name>.<namespace>.<kind>.<apiversion>
+	expectedProvisioner := fmt.Sprintf("%s.%s.%s.%s", claimName, claimNamespace, clusterClaim.Kind, clusterClaim.APIVersion)
 
 	patch := client.MergeFrom(cluster.DeepCopy())
 

--- a/controllers/managedcluster/managedcluster-controller_test.go
+++ b/controllers/managedcluster/managedcluster-controller_test.go
@@ -34,10 +34,10 @@ func TestReconcile(t *testing.T) {
 	}
 
 	if err := c.Client.Create(ctx, &hivev1.ClusterClaim{
-		// TypeMeta: metav1.TypeMeta{
-		// 	Kind:       "ClusterClaim",
-		// 	APIVersion: hivev1.SchemeGroupVersion.String(),
-		// },
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ClusterClaim",
+			APIVersion: hivev1.SchemeGroupVersion.String(),
+		},
 		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "testns"},
 		Spec:       hivev1.ClusterClaimSpec{},
 	}, &client.CreateOptions{}); err != nil {
@@ -72,8 +72,7 @@ func TestReconcile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// the crd.king and api version is not appearing in the annotation
-	expectedAnnotation := "test.testns"
+	expectedAnnotation := "test.testns.ClusterClaim.hive.openshift.io/v1"
 	if cluster.Annotations["cluster.open-cluster-management.io/provisioner"] != expectedAnnotation {
 		t.Errorf("unexpected annotation, expected: %v, got: %v", expectedAnnotation, cluster.Annotations["cluster.open-cluster-management.io/provisioner"])
 	}


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-16131