### PR TITLE
Add FIPS build flags to Dockerfile

### DIFF
--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -3,7 +3,7 @@ FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25 AS bui
 WORKDIR /go/src/github.com/stolostron/clusterclaims-controller
 COPY . .
 
-RUN make -f Makefile.prow compile-konflux
+RUN CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime make -f Makefile.prow compile-konflux
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 


### PR DESCRIPTION
## Summary
- Add `CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime` to `make compile` command in `Dockerfile.rhtap` for FIPS compliance

JIRA: HYPBLD-844

Made with [Cursor](https://cursor.com)